### PR TITLE
Remove superfluous "build" path element

### DIFF
--- a/src/Nuke.NSwag/NSwagSettings.cs
+++ b/src/Nuke.NSwag/NSwagSettings.cs
@@ -36,7 +36,7 @@ namespace Nuke.NSwag
         protected string GetToolPath ()
         {
             if (_isNetCore) return DotNetTasks.DotNetPath;
-            return GetPackageFrameworkDir() / "build"/"Win"/"NSwag.exe";
+            return GetPackageFrameworkDir() / "Win" / "NSwag.exe";
         }
 
         protected string GetNSwagRuntime ()
@@ -46,7 +46,7 @@ namespace Nuke.NSwag
 
         private string GetNetCoreDllPath(string runtime)
         {
-            return GetPackageFrameworkDir() / "build" / runtime / "dotnet-nswag.dll";
+            return GetPackageFrameworkDir() / runtime / "dotnet-nswag.dll";
         }
 
         private PathConstruction.AbsolutePath GetPackageFrameworkDir()


### PR DESCRIPTION
Otherwise, paths are constructed like 

    C:\Users\MyUser\.nuget\packages\nswag.msbuild\11.18.1\tools\build\NetCore21\dotnet-nswag.dll

Notice the `\tools\build`, it should only be `\tools`