### PR TITLE
Update NUKE to at least 0.11 to fix MissingMethodException

### DIFF
--- a/src/Nuke.NSwag/Nuke.NSwag.csproj
+++ b/src/Nuke.NSwag/Nuke.NSwag.csproj
@@ -19,6 +19,6 @@
   <Import Project="..\..\shared\Configuration.props" />
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="[0.6,1)" />
+    <PackageReference Include="Nuke.Common" Version="[0.11,1)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
With the current compilation, it gives the following `MissingMethodException`:

    Methode nicht gefunden: "InstalledPackage Nuke.Common.Tooling.NuGetPackageResolver.GetLocalInstalledPackage(System.String, System.String)".
       bei Nuke.NSwag.NSwagSettings.GetPackageFrameworkDir()
       bei Nuke.NSwag.NSwagSettings.GetNetCoreDllPath(String runtime)
       bei Nuke.NSwag.NSwagSettings.ConfigureArguments(Arguments arguments)
       bei Nuke.NSwag.NSwagExecuteDocumentSettings.ConfigureArguments(Arguments arguments)
       bei Nuke.Common.Tooling.ToolSettings.GetArguments()
       bei Nuke.Common.Tooling.ProcessManager.StartProcess(ToolSettings toolSettings)
       bei Nuke.NSwag.NSwagTasks.NSwagExecuteDocument(Configure`1 configurator)
       bei Build.<get_BuildInternalSwaggerClient>b__55_1()
       bei System.Collections.Generic.List`1.ForEach(Action`1 action)
       bei Nuke.Common.Execution.BuildExecutor.Execute(NukeBuild build, IEnumerable`1 executionList)
       bei Nuke.Common.Execution.BuildExecutor.Execute[T](Expression`1 defaultTargetExpression)

Only the following overloads are present:

    public static InstalledPackage GetLocalInstalledPackage(string packageId, string packagesConfigFile = null, bool includeDependencies = false);
    [IteratorStateMachine(typeof(<GetLocalInstalledPackages>d__3))]
    public static IEnumerable<InstalledPackage> GetLocalInstalledPackages(string packagesConfigFile = null, bool includeDependencies = false);

It is called in `NSwagSettings.cs`:

    private PathConstruction.AbsolutePath GetPackageFrameworkDir()
    {
        var package = NuGetPackageResolver.GetLocalInstalledPackage("nswag.msbuild")
            .NotNull("Package NSwag.MSBuild not found. Please install the package to your build project.");

        return package.Directory / (package.Version.Version >= new Version(major: 11, minor: 18, build: 1) ? "tools" : "build");
    }